### PR TITLE
Include openrc modifications by default

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+Scripts/my-openrc.sh
+Scripts/ContainerBuilderKey
+build/*
+.venv/*
+*.swp

--- a/Scripts/README.md
+++ b/Scripts/README.md
@@ -8,14 +8,8 @@ Servers may be spun up anywhere on the ORNL network and also the Titan login nod
 * Login to `cloud.cades.ornl.gov`
 * Navigate to `Compute -> Access & Security -> API Access`
 * Click `Download OpenStack RC File v3`
-* Rename downloaded file as openrc.sh and move it to `ContainerBuilder/Scripts`
+* Rename downloaded file as my-openrc.sh and move it to `ContainerBuilder/Scripts`
 * Modify `openrc.sh` to hardcode `$OS_PASSWORD_INPUT` and remove the interactive prompt
-* Add the following to the bottom of `openrc.sh`
-```
-export OS_PROJECT_DOMAIN_NAME=$OS_USER_DOMAIN_NAME
-export OS_IDENTITY_API_VERSION="3"
-export OS_CACERT=$(pwd)/OpenStack.cer
-```
 
 To initiate the Containerbuilder service several steps are required
 * Bring up the BuilderQueue OpenStack instance

--- a/Scripts/openrc.sh
+++ b/Scripts/openrc.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+source my-openrc.sh
+export OS_PROJECT_DOMAIN_NAME=$OS_USER_DOMAIN_NAME
+export OS_IDENTITY_API_VERSION="3"
+export OS_CACERT=$(pwd)/OpenStack.cer


### PR DESCRIPTION
In `Scripts/README.md` it says to add some things at the bottom of `openrc.sh` -- instead, I have added a default `openrc.sh` to the Scripts folder, and changed the README to direct folks to save their OpenStack RC file to `Scripts/my-openrc.sh`