### PR TITLE
Ignore creds and build artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+build/*
+.venv/*
+Scripts/openrc.sh
+Scripts/ContainerBuilderKey


### PR DESCRIPTION
Keeps openrc.sh and container keys from accidentally being tracked in version control